### PR TITLE
Versión 0.2.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 * text=auto
 
 # Do not put this files on a distribution package (by .gitignore)
+/tools/                 export-ignore
 /vendor/                export-ignore
 /composer.lock          export-ignore
 .phpunit.result.cache   export-ignore
@@ -9,6 +10,7 @@
 # Do not put this files on a distribution package
 /build/                 export-ignore
 /tests/                 export-ignore
+/.phive/                export-ignore
 /.gitattributes         export-ignore
 /.gitignore             export-ignore
 /.php_cs.dist           export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # do not include this files on git
-/vendor
+/tools/
+/vendor/
 /composer.lock
 .phpunit.result.cache

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^2.4" installed="2.18.2" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcbf" version="^3.0" installed="3.5.8" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpcs" version="^3.0" installed="3.5.8" location="./tools/phpcs" copy="false"/>
-  <phar name="phpstan" version="^0.12" installed="0.12.71" location="./tools/phpstan" copy="false"/>
-  <phar name="infection" version="^0.21.0" installed="0.21.0" location="./tools/infection" copy="false"/>
+  <phar name="php-cs-fixer" version="^2.4" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcbf" version="^3.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpcs" version="^3.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpstan" version="^0.12" location="./tools/phpstan" copy="false"/>
+  <phar name="infection" version="^0.21.0" location="./tools/infection" copy="false"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+  <phar name="php-cs-fixer" version="^2.4" installed="2.18.2" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcbf" version="^3.0" installed="3.5.8" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpcs" version="^3.0" installed="3.5.8" location="./tools/phpcs" copy="false"/>
+  <phar name="phpstan" version="^0.12" installed="0.12.71" location="./tools/phpstan" copy="false"/>
+</phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -4,4 +4,5 @@
   <phar name="phpcbf" version="^3.0" installed="3.5.8" location="./tools/phpcbf" copy="false"/>
   <phar name="phpcs" version="^3.0" installed="3.5.8" location="./tools/phpcs" copy="false"/>
   <phar name="phpstan" version="^0.12" installed="0.12.71" location="./tools/phpstan" copy="false"/>
+  <phar name="infection" version="^0.21.0" installed="0.21.0" location="./tools/infection" copy="false"/>
 </phive>

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -46,6 +46,6 @@ return PhpCsFixer\Config::create()
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
-            ->exclude(['vendor', 'build'])
+            ->exclude(['tools', 'vendor', 'build'])
     )
 ;

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,8 +7,7 @@ filter:
 build:
   dependencies:
     override:
-      - composer self-update --no-interaction --no-progress
-      - composer install --no-interaction --prefer-dist
+      - composer update --no-interaction --prefer-dist
   nodes:
     analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/
       project_setup:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -11,12 +11,13 @@ build:
       - composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
       - composer install --no-interaction --prefer-dist
   nodes:
-    analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/ 
-      project_setup: {override: true}
+    analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/
+      project_setup:
+        override: true
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis
-          - command: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+          - command: vendor/bin/phpunit --verbose --testdox --coverage-clover=coverage.clover
             coverage:
               file: coverage.clover
               format: clover

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,7 +8,6 @@ build:
   dependencies:
     override:
       - composer self-update --no-interaction --no-progress
-      - composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
       - composer install --no-interaction --prefer-dist
   nodes:
     analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php: ["7.3", "7.4", "8.0"]
 cache:
   - directories:
     - $HOME/.composer
+    - $HOME/.phive
 
 env:
   global:
@@ -15,12 +16,14 @@ before_script:
   - phpenv config-rm xdebug.ini || true
   - travis_retry composer self-update --no-interaction --2
   - travis_retry composer upgrade --no-interaction --prefer-dist
+  - wget -O phive https://phar.io/releases/phive.phar && chmod +x phive
+  - ./phive install --force-accept-unsigned --trust-gpg-keys 0x4AA394086372C20A,0x31C7E470E2138192,0xE82B2FB314E9906E,0xCF1A108D0E7AE720,0xC5095986493B4AA0
 
 script:
-  - vendor/bin/php-cs-fixer fix --dry-run --verbose
-  - vendor/bin/phpcbf --colors -sp src/ tests/ bin/
+  - tools/php-cs-fixer fix --dry-run --verbose
+  - tools/phpcs --colors -sp src/ tests/ bin/
   - vendor/bin/phpunit --testdox --verbose
-  - vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/  bin/
+  - tools/phpstan analyse --no-progress --verbose --level max src/ tests/  bin/
   - bash bin/check-current-max-occurs-paths.bash
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ cache:
     - $HOME/.composer
     - $HOME/.phive
 
-env:
-  global:
-    - PHP_CS_FIXER_IGNORE_ENV=yes
-
 before_script:
   - phpenv config-rm xdebug.ini || true
   - travis_retry composer self-update --no-interaction --2
@@ -20,7 +16,7 @@ before_script:
   - ./phive install --force-accept-unsigned --trust-gpg-keys 0x4AA394086372C20A,0x31C7E470E2138192,0xE82B2FB314E9906E,0xCF1A108D0E7AE720,0xC5095986493B4AA0
 
 script:
-  - tools/php-cs-fixer fix --dry-run --verbose
+  - PHP_CS_FIXER_IGNORE_ENV=yes tools/php-cs-fixer fix --dry-run --verbose
   - tools/phpcs --colors -sp src/ tests/ bin/
   - vendor/bin/phpunit --testdox --verbose
   - tools/phpstan analyse --no-progress --verbose --level max src/ tests/  bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   - vendor/bin/phpcbf --colors -sp src/ tests/ bin/
   - vendor/bin/phpunit --testdox --verbose
   - vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/  bin/
+  - bash bin/check-current-max-occurs-paths.bash
 
 notifications:
   email:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,15 @@ Considera las siguientes directrices:
 ## Proceso de construcción
 
 ```shell
+# Instala phive, sigue las indicaciones seguras de https://phar.io/#Install o la forma insegura:
+wget https://phar.io/releases/phive.phar -O ~/.local/bin/phive
+
+## Si no se han instalado las herramientas previamente
+phive install --force-accept-unsigned --trust-gpg-keys 0x4AA394086372C20A,0x31C7E470E2138192,0xE82B2FB314E9906E,0xCF1A108D0E7AE720,0xC5095986493B4AA0
+
 # Actualiza tus dependencias
 composer update
+phive update
 
 # Verificación de estilo de código
 composer dev:check-style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,9 @@ composer dev:test
 
 # Ejecución todo en uno, corregir estilo, verificar estilo y correr pruebas
 composer dev:build
+
+# Opcional: correr las pruebas de mutación
+composer dev:infection
 ```
 
 [phpCfdi]:      https://github.com/phpcfdi/

--- a/bin/check-current-max-occurs-paths.bash
+++ b/bin/check-current-max-occurs-paths.bash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash -e
+
+TEMPFILE="$(mktemp)"
+BINPATH="$(dirname $0)"
+
+echo "Creating UnboundedOccursPaths.json on $TEMPFILE"
+php "${BINPATH}/max-occurs-paths.php" > "$TEMPFILE"
+
+echo "Comparing to current UnboundedOccursPaths.json"
+diff -u -b -B "${BINPATH}/../src/UnboundedOccursPaths.json" "$TEMPFILE"
+
+echo "OK: Files match"
+rm "$TEMPFILE"

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,7 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3",
-        "squizlabs/php_codesniffer": "^3.0",
-        "friendsofphp/php-cs-fixer": "^2.4",
-        "phpstan/phpstan": "^0.12"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {
@@ -35,16 +32,16 @@
     "scripts": {
         "dev:build": ["@dev:fix-style", "@dev:check-style", "@dev:test"],
         "dev:check-style": [
-            "vendor/bin/php-cs-fixer fix --dry-run --verbose",
-            "vendor/bin/phpcs --colors -sp src/ tests/ bin/"
+            "tools/php-cs-fixer fix --dry-run --verbose",
+            "tools/phpcs --colors -sp src/ tests/ bin/"
         ],
         "dev:fix-style": [
-            "vendor/bin/php-cs-fixer fix --verbose",
-            "vendor/bin/phpcbf --colors -sp src/ tests/ bin/"
+            "tools/php-cs-fixer fix --verbose",
+            "tools/phpcbf --colors -sp src/ tests/ bin/"
         ],
         "dev:test": [
             "vendor/bin/phpunit --testdox --verbose --stop-on-failure",
-            "vendor/bin/phpstan analyse --verbose --level max src/ tests/ bin/"
+            "tools/phpstan analyse --verbose --level max src/ tests/ bin/"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-html build/coverage/html/"

--- a/composer.json
+++ b/composer.json
@@ -32,19 +32,19 @@
     "scripts": {
         "dev:build": ["@dev:fix-style", "@dev:check-style", "@dev:test"],
         "dev:check-style": [
-            "tools/php-cs-fixer fix --dry-run --verbose",
-            "tools/phpcs --colors -sp src/ tests/ bin/"
+            "@php tools/php-cs-fixer fix --dry-run --verbose",
+            "@php tools/phpcs --colors -sp src/ tests/ bin/"
         ],
         "dev:fix-style": [
-            "tools/php-cs-fixer fix --verbose",
-            "tools/phpcbf --colors -sp src/ tests/ bin/"
+            "@php tools/php-cs-fixer fix --verbose",
+            "@php tools/phpcbf --colors -sp src/ tests/ bin/"
         ],
         "dev:test": [
-            "vendor/bin/phpunit --testdox --verbose --stop-on-failure",
-            "tools/phpstan analyse --verbose --level max src/ tests/ bin/"
+            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
+            "@php tools/phpstan analyse --verbose --level max src/ tests/ bin/"
         ],
         "dev:coverage": [
-            "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-html build/coverage/html/"
+            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --coverage-xml build/coverage/xml/ --coverage-html build/coverage/html/"
         ],
         "dev:infection": [
             "@php tools/infection --show-mutations --no-progress"
@@ -54,7 +54,7 @@
         "dev:build": "DEV: run dev:fix-style and dev:tests, run before pull request",
         "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run phpunit and phpstan",
+        "dev:test": "DEV: run dev:fix-style, phpunit and phpstan",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/",
         "dev:infection": "DEV: run mutation tests using infection"
     }

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,9 @@
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-html build/coverage/html/"
+        ],
+        "dev:infection": [
+            "@php tools/infection --show-mutations --no-progress"
         ]
     },
     "scripts-descriptions": {
@@ -52,6 +55,7 @@
         "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
         "dev:test": "DEV: run phpunit and phpstan",
-        "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
+        "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/",
+        "dev:infection": "DEV: run mutation tests using infection"
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 
 ## Listado de cambios
 
+### Versión 0.1.1 2021-02-04
+
+- Conseguir el 100% de testeo.
+
 ### Versión 0.1.0 2021-02-02 ¡Feliz cumpleaños Dany!
 
 - Primera liberación para su uso público.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 ### Versión 0.1.1 2021-02-04
 
 - Conseguir el 100% de testeo.
+- Agregar a Travis-CI la comprobación de que el archivo `src/UnboundedOccursPaths.json` no ha cambiado.
 
 ### Versión 0.1.0 2021-02-02 ¡Feliz cumpleaños Dany!
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 
 - Conseguir el 100% de testeo.
 - Agregar a Travis-CI la comprobación de que el archivo `src/UnboundedOccursPaths.json` no ha cambiado.
+- Usar `phive` para las herramientas de desarrollo.
 
 ### Versión 0.1.0 2021-02-02 ¡Feliz cumpleaños Dany!
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,11 +11,13 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 
 ## Listado de cambios
 
-### Versión 0.1.1 2021-02-04
+### Versión 0.2.0 2021-03-22
 
+- Se extrae la lógica del conteo de hijos de `Nodes\Children` a `Nodes\KeysCounter`.
 - Conseguir el 100% de testeo.
 - Agregar a Travis-CI la comprobación de que el archivo `src/UnboundedOccursPaths.json` no ha cambiado.
 - Usar `phive` para las herramientas de desarrollo.
+- Se agrega `infection` para correr pruebas de mutación. No es mandatorio por el momento.
 
 ### Versión 0.1.0 2021-02-02 ¡Feliz cumpleaños Dany!
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 ### Versión 0.2.0 2021-03-22
 
 - Se extrae la lógica del conteo de hijos de `Nodes\Children` a `Nodes\KeysCounter`.
+- Se corrigen los test y las llamadas de `file_get_contents`.
 - Conseguir el 100% de testeo.
 - Agregar a Travis-CI la comprobación de que el archivo `src/UnboundedOccursPaths.json` no ha cambiado.
 - Usar `phive` para las herramientas de desarrollo.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,4 +4,4 @@
 
 - ¿Los elementos `Comprobante/Complemento` deberían colapsarse?
 
-- Usar infection
+- Hacer que `infection` se ejecute con un mínimo requerido en la integración contínua.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,8 +2,6 @@
 
 ## Ideas, por favor, levante un ticket para discutirlas
 
-- Agregar a Travis la comprobación del archivo `src/UnboundedOccursPaths.json`
-
 - ¿Los elementos `Comprobante/Complemento` deberían colapsarse?
 
 - Usar infection

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,15 @@
+{
+    "source": {
+        "directories": [
+            "bin",
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "build\/infection.log"
+    },
+    "mutators": {
+        "@default": true
+    },
+    "initialTestsPhpOptions": "-dzend_extension=xdebug.so"
+}

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,7 +1,6 @@
 {
     "source": {
         "directories": [
-            "bin",
             "src"
         ]
     },
@@ -11,5 +10,5 @@
     "mutators": {
         "@default": true
     },
-    "initialTestsPhpOptions": "-dzend_extension=xdebug.so"
+    "initialTestsPhpOptions": "-dzend_extension=xdebug.so -dxdebug.mode=coverage"
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,7 @@
     <arg name="encoding" value="utf-8"/>
     <arg name="report-width" value="auto"/>
     <arg name="extensions" value="php"/>
+    <arg name="cache" value="build/phpcs.cache"/>
     <rule ref="PSR2"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>

--- a/src/CfdiToDataNode.php
+++ b/src/CfdiToDataNode.php
@@ -15,9 +15,14 @@ final class CfdiToDataNode
     /** @var UnboundedOccursPaths */
     private $unboundedOccursPaths;
 
-    public function __construct(UnboundedOccursPaths $multipleChildrenPaths)
+    public function __construct(UnboundedOccursPaths $unboundedOccursPaths)
     {
-        $this->unboundedOccursPaths = $multipleChildrenPaths;
+        $this->unboundedOccursPaths = $unboundedOccursPaths;
+    }
+
+    public function getUnboundedOccursPaths(): UnboundedOccursPaths
+    {
+        return $this->unboundedOccursPaths;
     }
 
     public function convertXmlContent(string $xmlContents): Nodes\Node

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,6 +6,7 @@ namespace PhpCfdi\CfdiToJson;
 
 use JsonException;
 use LogicException;
+use Throwable;
 
 final class Factory
 {
@@ -35,7 +36,11 @@ final class Factory
 
     public function createUnboundedOccursPathsUsingJsonFile(string $sourceFile): UnboundedOccursPaths
     {
-        $contents = file_get_contents($sourceFile);
+        try {
+            $contents = file_get_contents($sourceFile);
+        } catch (Throwable $exception) {
+            throw new LogicException("Unable to open file $sourceFile", 0, $exception);
+        }
         if (false === $contents) {
             throw new LogicException("Unable to open file $sourceFile");
         }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,7 +6,6 @@ namespace PhpCfdi\CfdiToJson;
 
 use JsonException;
 use LogicException;
-use Throwable;
 
 final class Factory
 {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -36,11 +36,7 @@ final class Factory
 
     public function createUnboundedOccursPathsUsingJsonFile(string $sourceFile): UnboundedOccursPaths
     {
-        try {
-            $contents = file_get_contents($sourceFile);
-        } catch (Throwable $exception) {
-            throw new LogicException("Unable to open file $sourceFile", 0, $exception);
-        }
+        $contents = file_get_contents($sourceFile);
         if (false === $contents) {
             throw new LogicException("Unable to open file $sourceFile");
         }

--- a/src/Nodes/Children.php
+++ b/src/Nodes/Children.php
@@ -14,29 +14,25 @@ final class Children
     /** @var UnboundedOccursPaths */
     private $unboundedOccursPaths;
 
-    /** @var array<string, int> */
-    private $childrenCountByKey = [];
+    /** @var KeysCounter */
+    private $keysCounter;
 
     public function __construct(UnboundedOccursPaths $unboundedOccursPaths)
     {
         $this->unboundedOccursPaths = $unboundedOccursPaths;
+        $this->keysCounter = new KeysCounter();
     }
 
     public function append(Node $child): void
     {
         $this->children[] = $child;
-        $this->childrenCountByKey[$child->getKey()] = $this->getChildrenCountByKey($child->getKey()) + 1;
+        $this->keysCounter->register($child->getKey());
     }
 
     public function isChildrenMultiple(Node $child): bool
     {
-        return ($this->getChildrenCountByKey($child->getKey()) > 1)
+        return $this->keysCounter->hasMany($child->getKey())
             || $this->unboundedOccursPaths->match($child->getPath());
-    }
-
-    private function getChildrenCountByKey(string $key): int
-    {
-        return $this->childrenCountByKey[$key] ?? 0;
     }
 
     /** @return array<string, string|array> */

--- a/src/Nodes/Children.php
+++ b/src/Nodes/Children.php
@@ -25,7 +25,7 @@ final class Children
     public function append(Node $child): void
     {
         $this->children[] = $child;
-        $this->childrenCountByKey[$child->getKey()] = $this->getChildrenCountByKey($child->getKey());
+        $this->childrenCountByKey[$child->getKey()] = $this->getChildrenCountByKey($child->getKey()) + 1;
     }
 
     public function isChildrenMultiple(Node $child): bool

--- a/src/Nodes/KeysCounter.php
+++ b/src/Nodes/KeysCounter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiToJson\Nodes;
+
+final class KeysCounter
+{
+    /** @var array<string, int> */
+    private $counts;
+
+    public function register(string $key): void
+    {
+        $this->counts[$key] = $this->get($key) + 1;
+    }
+
+    public function get(string $key): int
+    {
+        return $this->counts[$key] ?? 0;
+    }
+
+    public function hasMany(string $key): bool
+    {
+        return $this->get($key) > 1;
+    }
+}

--- a/src/XsdMaxOccurs/Downloader.php
+++ b/src/XsdMaxOccurs/Downloader.php
@@ -11,11 +11,8 @@ final class Downloader implements DownloaderInterface
 {
     public function get(string $url): string
     {
-        try {
-            $contents = file_get_contents($url);
-        } catch (Throwable $exception) {
-            throw new RuntimeException("Unable to get $url contents", 0, $exception);
-        }
+        /** @noinspection PhpUsageOfSilenceOperatorInspection */
+        $contents = @file_get_contents($url);
         if (false === $contents) {
             throw new RuntimeException("Unable to get $url contents");
         }

--- a/src/XsdMaxOccurs/Downloader.php
+++ b/src/XsdMaxOccurs/Downloader.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiToJson\XsdMaxOccurs;
 
 use RuntimeException;
-use Throwable;
 
 final class Downloader implements DownloaderInterface
 {

--- a/src/XsdMaxOccurs/Finder.php
+++ b/src/XsdMaxOccurs/Finder.php
@@ -17,9 +17,9 @@ final class Finder implements FinderInterface
         $document->loadXML($xsdContents);
 
         return array_merge(
-            $this->obtainPathsForXPathQuery($document, '//xs:element[@maxOccurs="unbounded"]'),
-            $this->obtainPathsForXPathQuery($document, '//xs:sequence[@maxOccurs="unbounded"]/xs:element'),
-            $this->obtainPathsForXPathQuery($document, '//xs:choice[@maxOccurs="unbounded"]/xs:element'),
+            $this->obtainPathsForXPathQuery($document, '//x:element[@maxOccurs="unbounded"]'),
+            $this->obtainPathsForXPathQuery($document, '//x:sequence[@maxOccurs="unbounded"]/x:element'),
+            $this->obtainPathsForXPathQuery($document, '//x:choice[@maxOccurs="unbounded"]/x:element'),
         );
     }
 
@@ -32,7 +32,7 @@ final class Finder implements FinderInterface
     {
         $paths = [];
         $xpath = new DOMXPath($document);
-        $xpath->registerNamespace('xs', 'http://www.w3.org/2001/XMLSchema');
+        $xpath->registerNamespace('x', 'http://www.w3.org/2001/XMLSchema');
         $nodes = $xpath->query($query) ?: new DOMNodeList();
         foreach ($nodes as $node) {
             if ($node instanceof DOMElement) {

--- a/tests/Functional/ConverterTest.php
+++ b/tests/Functional/ConverterTest.php
@@ -57,8 +57,10 @@ final class ConverterTest extends TestCase
     public function testJsonConverter(): void
     {
         $xmlContents = $this->fileContents('cfdi-example.xml');
+        $jsonFile = $this->filePath('cfdi-example.json');
         /** @noinspection PhpUnhandledExceptionInspection */
         $json = JsonConverter::convertToJson($xmlContents);
-        $this->assertJsonStringEqualsJsonString(json_encode($this->data) ?: '', $json);
+        $this->assertJsonStringEqualsJsonFile($jsonFile, $json);
+        $this->assertStringEqualsFile($jsonFile, $json, 'Check that the default format is preserved');
     }
 }

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -32,9 +32,8 @@ final class FactoryTest extends TestCase
     public function testCreateUnboundedOccursPathsUsingJsonFileUsingInvalidFileWithErrorReporting(): void
     {
         $factory = new Factory(new UnboundedOccursPaths());
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Unable to open file');
-        $factory->createUnboundedOccursPathsUsingJsonFile(__DIR__);
+        $this->expectWarning();
+        $factory->createUnboundedOccursPathsUsingJsonFile(__DIR__ . '/not-found');
     }
 
     public function testCreateUnboundedOccursPathsUsingJsonFileUsingInvalidFileWithoutErrorReporting(): void
@@ -44,12 +43,8 @@ final class FactoryTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Unable to open file');
 
-        $previousErrorReporting = error_reporting(0);
-        try {
-            $factory->createUnboundedOccursPathsUsingJsonFile(__DIR__ . '/not-found');
-        } finally {
-            error_reporting($previousErrorReporting);
-        }
+        /** @noinspection PhpUsageOfSilenceOperatorInspection */
+        @$factory->createUnboundedOccursPathsUsingJsonFile(__DIR__ . '/not-found');
     }
 
     public function testCreateUnboundedOccursPathsUsingJsonFileUsingInvalidContents(): void

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiToJson\Tests\Unit;
+
+use JsonException;
+use LogicException;
+use PhpCfdi\CfdiToJson\Factory;
+use PhpCfdi\CfdiToJson\Tests\TestCase;
+use PhpCfdi\CfdiToJson\UnboundedOccursPaths;
+
+final class FactoryTest extends TestCase
+{
+    public function testConstructFactoryUsesDefaultUnboundedOccursPaths(): void
+    {
+        $factory = new Factory();
+        $this->assertEquals($factory->createDefaultUnboundedOccursPaths(), $factory->getUnboundedOccursPaths());
+    }
+
+    public function testConstructFactoryUsesGivenUnboundedOccursPaths(): void
+    {
+        $unboundedOccursPaths = new UnboundedOccursPaths();
+        $factory = new Factory($unboundedOccursPaths);
+        $this->assertEquals($unboundedOccursPaths, $factory->getUnboundedOccursPaths());
+        $converter = $factory->createConverter();
+        $this->assertSame($unboundedOccursPaths, $converter->getUnboundedOccursPaths());
+    }
+
+    public function testCreateUnboundedOccursPathsUsingJsonFileUsingInvalidFileWithErrorReporting(): void
+    {
+        $factory = new Factory(new UnboundedOccursPaths());
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Unable to open file');
+        $factory->createUnboundedOccursPathsUsingJsonFile(__DIR__);
+    }
+
+    public function testCreateUnboundedOccursPathsUsingJsonFileUsingInvalidFileWithoutErrorReporting(): void
+    {
+        $factory = new Factory(new UnboundedOccursPaths());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Unable to open file');
+
+        $previousErrorReporting = error_reporting(0);
+        try {
+            $factory->createUnboundedOccursPathsUsingJsonFile(__DIR__ . '/not-found');
+        } finally {
+            error_reporting($previousErrorReporting);
+        }
+    }
+
+    public function testCreateUnboundedOccursPathsUsingJsonFileUsingInvalidContents(): void
+    {
+        $factory = new Factory(new UnboundedOccursPaths());
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('has invalid contents');
+        $factory->createUnboundedOccursPathsUsingJsonFile(__FILE__);
+    }
+
+    public function testCreateUnboundedOccursPathsUsingJsonSourceWithInvalidJson(): void
+    {
+        $factory = new Factory(new UnboundedOccursPaths());
+        $this->expectException(JsonException::class);
+        $factory->createUnboundedOccursPathsUsingJsonSource('');
+    }
+
+    public function testCreateUnboundedOccursPathsUsingJsonNotArray(): void
+    {
+        $factory = new Factory(new UnboundedOccursPaths());
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('JSON does not contains an array of entries');
+        $factory->createUnboundedOccursPathsUsingJsonSource('""');
+    }
+
+    public function testCreateUnboundedOccursPathsUsingJsonNotArrayOfStrings(): void
+    {
+        $factory = new Factory(new UnboundedOccursPaths());
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('JSON does not contains a string on index 1');
+        $factory->createUnboundedOccursPathsUsingJsonSource('["string", 2]');
+    }
+}

--- a/tests/Unit/Nodes/ChildrenTest.php
+++ b/tests/Unit/Nodes/ChildrenTest.php
@@ -11,18 +11,14 @@ use PhpCfdi\CfdiToJson\UnboundedOccursPaths;
 
 final class ChildrenTest extends TestCase
 {
-    public function testGetChildrenCountByKey(): void
+    public function testIsChildrenMultipleDetectDuplicatedNodeNames(): void
     {
         $unboundedOccursPaths = new UnboundedOccursPaths();
         $children = new Children($unboundedOccursPaths);
-        $children->append($nodeAuthor = new Node('author', '/', [], new Children($unboundedOccursPaths)));
-        $children->append($nodeChapter = new Node('chapter', '/', [], new Children($unboundedOccursPaths)));
-        $children->append(new Node('chapter', '/', [], new Children($unboundedOccursPaths)));
+        $nodeChapter = new Node('chapter', '/', [], new Children($unboundedOccursPaths));
+        $children->append($nodeChapter);
+        $children->append($nodeChapter);
 
-        $this->assertFalse($children->isChildrenMultiple($nodeAuthor));
         $this->assertTrue($children->isChildrenMultiple($nodeChapter));
-
-        $nodeNonExistent = new Node('non-existent', '/', [], new Children($unboundedOccursPaths));
-        $this->assertFalse($children->isChildrenMultiple($nodeNonExistent));
     }
 }

--- a/tests/Unit/Nodes/ChildrenTest.php
+++ b/tests/Unit/Nodes/ChildrenTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiToJson\Tests\Unit\Nodes;
+
+use PhpCfdi\CfdiToJson\Nodes\Children;
+use PhpCfdi\CfdiToJson\Nodes\Node;
+use PhpCfdi\CfdiToJson\Tests\TestCase;
+use PhpCfdi\CfdiToJson\UnboundedOccursPaths;
+
+final class ChildrenTest extends TestCase
+{
+    public function testGetChildrenCountByKey(): void
+    {
+        $unboundedOccursPaths = new UnboundedOccursPaths();
+        $children = new Children($unboundedOccursPaths);
+        $children->append($nodeAuthor = new Node('author', '/', [], new Children($unboundedOccursPaths)));
+        $children->append($nodeChapter = new Node('chapter', '/', [], new Children($unboundedOccursPaths)));
+        $children->append(new Node('chapter', '/', [], new Children($unboundedOccursPaths)));
+
+        $this->assertFalse($children->isChildrenMultiple($nodeAuthor));
+        $this->assertTrue($children->isChildrenMultiple($nodeChapter));
+
+        $nodeNonExistent = new Node('non-existent', '/', [], new Children($unboundedOccursPaths));
+        $this->assertFalse($children->isChildrenMultiple($nodeNonExistent));
+    }
+}

--- a/tests/Unit/Nodes/KeysCounterTest.php
+++ b/tests/Unit/Nodes/KeysCounterTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiToJson\Tests\Unit\Nodes;
+
+use PhpCfdi\CfdiToJson\Nodes\KeysCounter;
+use PhpCfdi\CfdiToJson\Tests\TestCase;
+
+final class KeysCounterTest extends TestCase
+{
+    private function createPopulatedCounter(string ...$keys): KeysCounter
+    {
+        $counter = new KeysCounter();
+        foreach ($keys as $key) {
+            $counter->register($key);
+        }
+        return $counter;
+    }
+
+    public function testHasMany(): void
+    {
+        $counter = $this->createPopulatedCounter('author', 'chapter', 'chapter');
+
+        $this->assertTrue($counter->hasMany('chapter'));
+        $this->assertFalse($counter->hasMany('author'));
+        $this->assertFalse($counter->hasMany('non-existent'));
+    }
+
+    public function testGet(): void
+    {
+        $counter = $this->createPopulatedCounter('author', 'chapter', 'chapter');
+
+        $this->assertSame(2, $counter->get('chapter'));
+        $this->assertSame(1, $counter->get('author'));
+        $this->assertSame(0, $counter->get('non-existent'));
+    }
+}

--- a/tests/Unit/XsdMaxOccurs/DownloaderTest.php
+++ b/tests/Unit/XsdMaxOccurs/DownloaderTest.php
@@ -22,7 +22,6 @@ final class DownloaderTest extends TestCase
 
     public function testDownloaderThrowsExceptionWhenCannotGetContentsWithoutErrorReporting(): void
     {
-
         $url = __DIR__ . '/file-not-found';
         $downloader = new Downloader();
 

--- a/tests/Unit/XsdMaxOccurs/DownloaderTest.php
+++ b/tests/Unit/XsdMaxOccurs/DownloaderTest.php
@@ -22,16 +22,19 @@ final class DownloaderTest extends TestCase
 
     public function testDownloaderThrowsExceptionWhenCannotGetContentsWithoutErrorReporting(): void
     {
-        $previousErrorReporting = error_reporting(0);
 
         $url = __DIR__ . '/file-not-found';
         $downloader = new Downloader();
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Unable to get $url contents");
-        $downloader->get($url);
 
-        error_reporting($previousErrorReporting);
+        $previousErrorReporting = error_reporting(0);
+        try {
+            $downloader->get($url);
+        } finally {
+            error_reporting($previousErrorReporting);
+        }
     }
 
     public function testDownloaderThrowsExceptionWhenContentIsEmpty(): void

--- a/tests/Unit/XsdMaxOccurs/DownloaderTest.php
+++ b/tests/Unit/XsdMaxOccurs/DownloaderTest.php
@@ -28,12 +28,8 @@ final class DownloaderTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Unable to get $url contents");
 
-        $previousErrorReporting = error_reporting(0);
-        try {
-            $downloader->get($url);
-        } finally {
-            error_reporting($previousErrorReporting);
-        }
+        /** @noinspection PhpUsageOfSilenceOperatorInspection */
+        @$downloader->get($url);
     }
 
     public function testDownloaderThrowsExceptionWhenContentIsEmpty(): void

--- a/tests/_files/cfdi-example.json
+++ b/tests/_files/cfdi-example.json
@@ -1,0 +1,115 @@
+{
+    "Certificado": "MIIGHTCCBAWgAwIBAgIUMDAwMDEwMDAwMDA0MDEyMjA0NTEwDQYJKoZIhvcNAQELBQAwggGyMTgwNgYDVQQDDC9BLkMuIGRlbCBTZXJ2aWNpbyBkZSBBZG1pbmlzdHJhY2nDs24gVHJpYnV0YXJpYTEvMC0GA1UECgwmU2VydmljaW8gZGUgQWRtaW5pc3RyYWNpw7NuIFRyaWJ1dGFyaWExODA2BgNVBAsML0FkbWluaXN0cmFjacOzbiBkZSBTZWd1cmlkYWQgZGUgbGEgSW5mb3JtYWNpw7NuMR8wHQYJKoZIhvcNAQkBFhBhY29kc0BzYXQuZ29iLm14MSYwJAYDVQQJDB1Bdi4gSGlkYWxnbyA3NywgQ29sLiBHdWVycmVybzEOMAwGA1UEEQwFMDYzMDAxCzAJBgNVBAYTAk1YMRkwFwYDVQQIDBBEaXN0cml0byBGZWRlcmFsMRQwEgYDVQQHDAtDdWF1aHTDqW1vYzEVMBMGA1UELRMMU0FUOTcwNzAxTk4zMV0wWwYJKoZIhvcNAQkCDE5SZXNwb25zYWJsZTogQWRtaW5pc3RyYWNpw7NuIENlbnRyYWwgZGUgU2VydmljaW9zIFRyaWJ1dGFyaW9zIGFsIENvbnRyaWJ1eWVudGUwHhcNMTYwMTIwMTYwNjA5WhcNMjAwMTIwMTYwNjA5WjCBvTEgMB4GA1UEAxMXUFJPTU9UT1JBIE9USVIgU0EgREUgQ1YxIDAeBgNVBCkTF1BST01PVE9SQSBPVElSIFNBIERFIENWMSAwHgYDVQQKExdQUk9NT1RPUkEgT1RJUiBTQSBERSBDVjElMCMGA1UELRMcUE9UOTIwNzIxM0Q2IC8gT0VFSjY4MDQyMEJIMDEeMBwGA1UEBRMVIC8gT0VFSjY4MDQyMEhERlRTUzAxMQ4wDAYDVQQLEwVIT1RFTDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL2mhr0fghMamEYiMbqNpOnxn2VV4ZER6uNnL+WBa+D/G5fDQhHApO8WCim+ubrVnZO8qRw1BNhpMjsRuINIbl3uG+XVXP966CgCuy6JZ6sLAFqI3oxLHTJypW8rq12oGPtiaDfPqTH1kFtPM5AkKqE6zUt/LmWOVp34erImk9zqXD1HyDdBmmG7diAHJxH2GGfli6kbhXKPcPSvmI9Mv6cwUM7VBcUMC/j0hRLnNcxKz9HmIyJUk2F5lpdf93cTgNZl9Pf5+LgPU8J8T4/06ma6JxFgABWj2qqIsQCk8BNhivkfuWP4Mz90cdbVvthZJ3pudB0WnOjksAdKOyUvlmUCAwEAAaMdMBswDAYDVR0TAQH/BAIwADALBgNVHQ8EBAMCBsAwDQYJKoZIhvcNAQELBQADggIBADCko/5cy6b1VqckgjGuhBE/Lls1Wwu4UuU9Gr6tDxqtLUbUbris+eBqnXBQ6lzjTMhbyGVh3OFUkzI6RXk7Yi+AIrWwAPUPVx91x1fmOfm/hHY1mLEcU3t692+gzuGusC69jZaGl4HvcSxePWLMUVf/WZIWRoYdcdpWK9XJPtJvL6IvntBwaGLJA1ao2xyJweqQ3dM1HvRQ1ISdRpqIdORtHoLjpaefmXwdihx5HDpYtQYm60Yf+N8IHkm9FdreiyQLJbyERF22FZAqLtn8V5u/Tssj2BlVZO3hq7rQRd1PRaiXJooW4IXraesDi2eClwbJQ6gonjqaqAfsadwgkTNFmGlsL+YHWaNI4l2e30bj04SLGNC//Vb3vA0NVqPecZKGJiwy9/DHqBSLW6bItdfH+nAo4VUxD061cxBpSgnJzMwZR8xUbtfoxIiExp9vk+TWluCY9B486eBy0nIF6TNGT5XXRb2yJb2BYWR9AIc1awcG9wew1YKu1Ho2bdYDGmYRTZu532JaMiOjfVt+NTFXMMuSzrdkMwFYR7PbT/4VVJFMW5QtYhaMZr0QxiVjmGCLbIYBEan8MsdW7K8g0ZGwPJ6yBbbids/FV7nc1NquLKqTJPkng3vTO7cweVufU3A4QWqwR41yNTTx0QC5xeyTMl5gEQAJ2Urmx7GimAyX",
+    "CondicionesDePago": "CONTADO",
+    "Fecha": "2018-01-12T08:15:01",
+    "Folio": "11541",
+    "FormaPago": "04",
+    "LugarExpedicion": "76802",
+    "MetodoPago": "PUE",
+    "Moneda": "MXN",
+    "NoCertificado": "00001000000401220451",
+    "Sello": "Xt7tK83WumikNMyx4Y/Z3R7D0rOjqTrrLu8wBlCnvXrpMFgWtyrcFUttGnevvUqCnQjuVUSpFcXqbzIQEUYNKFjxmtjwGHN+b15xUvcnfqpJRBoJe2IKd5YMZqYp9NhTJIMBYsE7+fhP1+mHcKdKn9WwXrar8uXzISqPgZ97AORBsMWmXxbVWYRtqT4MX/Xq4yhbT4jaoaut5AwhVzE1TUyZ10/C2gGySQeFVyEp9aqNScIxPotVDb7fMIWxsV26XODf6GK14B0TJNmRlCIfmfb2rQeskiYeiF5AQPb6Z2gmGLHcNks7qC+eO3EsGVr1/ntmGcwTurbGXmE4/OAgdg==",
+    "Serie": "H",
+    "SubTotal": "1709.12",
+    "TipoDeComprobante": "I",
+    "Total": "2010.01",
+    "Version": "3.3",
+    "xsi:schemaLocation": "http://www.sat.gob.mx/cfd/3 http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv33.xsd http://www.sat.gob.mx/implocal http://www.sat.gob.mx/sitio_internet/cfd/implocal/implocal.xsd",
+    "Emisor": {
+        "Nombre": "PROMOTORA OTIR SA DE CV",
+        "RegimenFiscal": "601",
+        "Rfc": "POT9207213D6"
+    },
+    "Receptor": {
+        "Nombre": "DAY INTERNATIONAL DE MEXICO SA DE CV",
+        "Rfc": "DIM8701081LA",
+        "UsoCFDI": "G03"
+    },
+    "Conceptos": {
+        "Concepto": [
+            {
+                "Cantidad": "2.00",
+                "ClaveProdServ": "90111501",
+                "ClaveUnidad": "E48",
+                "Descripcion": "Paquete",
+                "Importe": "1355.67",
+                "Unidad": "UNIDAD DE SERVICIO",
+                "ValorUnitario": "677.83",
+                "Impuestos": {
+                    "Traslados": {
+                        "Traslado": [
+                            {
+                                "Base": "1355.67",
+                                "Importe": "216.91",
+                                "Impuesto": "002",
+                                "TasaOCuota": "0.160000",
+                                "TipoFactor": "Tasa"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "Cantidad": "1.00",
+                "ClaveProdServ": "90101501",
+                "ClaveUnidad": "E48",
+                "Descripcion": "Restaurante",
+                "Importe": "353.45",
+                "Unidad": "UNIDAD DE SERVICIO",
+                "ValorUnitario": "353.45",
+                "Impuestos": {
+                    "Traslados": {
+                        "Traslado": [
+                            {
+                                "Base": "353.45",
+                                "Importe": "56.55",
+                                "Impuesto": "002",
+                                "TasaOCuota": "0.160000",
+                                "TipoFactor": "Tasa"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "Impuestos": {
+        "TotalImpuestosTrasladados": "273.46",
+        "Traslados": {
+            "Traslado": [
+                {
+                    "Importe": "273.46",
+                    "Impuesto": "002",
+                    "TasaOCuota": "0.160000",
+                    "TipoFactor": "Tasa"
+                }
+            ]
+        }
+    },
+    "Complemento": [
+        {
+            "ImpuestosLocales": {
+                "TotaldeRetenciones": "0.00",
+                "TotaldeTraslados": "27.43",
+                "version": "1.0",
+                "TrasladosLocales": [
+                    {
+                        "ImpLocTrasladado": "IH",
+                        "Importe": "27.43",
+                        "TasadeTraslado": "2.50"
+                    }
+                ]
+            },
+            "TimbreFiscalDigital": {
+                "FechaTimbrado": "2018-01-12T08:17:54",
+                "NoCertificadoSAT": "00001000000406258094",
+                "RfcProvCertif": "DCD090706E42",
+                "SelloCFD": "Xt7tK83WumikNMyx4Y/Z3R7D0rOjqTrrLu8wBlCnvXrpMFgWtyrcFUttGnevvUqCnQjuVUSpFcXqbzIQEUYNKFjxmtjwGHN+b15xUvcnfqpJRBoJe2IKd5YMZqYp9NhTJIMBYsE7+fhP1+mHcKdKn9WwXrar8uXzISqPgZ97AORBsMWmXxbVWYRtqT4MX/Xq4yhbT4jaoaut5AwhVzE1TUyZ10/C2gGySQeFVyEp9aqNScIxPotVDb7fMIWxsV26XODf6GK14B0TJNmRlCIfmfb2rQeskiYeiF5AQPb6Z2gmGLHcNks7qC+eO3EsGVr1/ntmGcwTurbGXmE4/OAgdg==",
+                "SelloSAT": "IRy7wQnKnlIsN/pSZSR7qEm/SOJuLIbNjj/S3EAd278T2uo0t73KXfXzUbbfWOwpdZEAZeosq/yEiStTaf44ZonqRS1fq6oYk12udMmT4NFrEYbPEEKLn4lqdhuW4v8ZK2Vos/pjCtYtpT+/oVIXiWg9KrGVGuMvygRPWSmd+YJq3Jm7qTz0ON0vzBOvXralSZ4Q14xUvt6ZDM9gYqIzTtCjIWaNrAdEYyqfZjvfy0uCyThh6HvCbMsX9gq4RsQj3SIoA56g+1SJevoZ6Jr722mDCLcPox3KCN75Bk8ALJI6G0weP7rQO5jEtulTRNWN3w+tlryZWElkD79MDZA6Zg==",
+                "UUID": "CEE4BE01-ADFA-4DEB-8421-ADD60F0BEDAC",
+                "Version": "1.1",
+                "xsi:schemaLocation": "http://www.sat.gob.mx/TimbreFiscalDigital http://www.sat.gob.mx/sitio_internet/cfd/TimbreFiscalDigital/TimbreFiscalDigitalv11.xsd"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
- Se extrae la lógica del conteo de hijos de `Nodes\Children` a `Nodes\KeysCounter`.
- Se corrigen los test y las llamadas de `file_get_contents`.
- Conseguir el 100% de testeo.
- Agregar a Travis-CI la comprobación de que el archivo `src/UnboundedOccursPaths.json` no ha cambiado.
- Usar `phive` para las herramientas de desarrollo.
- Se agrega `infection` para correr pruebas de mutación. No es mandatorio por el momento.
