### PR TITLE
Corregir CI 20240403 (Versión 0.3.1)

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.7.0" location="./tools/php-cs-fixer" copy="false" installed="3.7.0"/>
+  <phar name="php-cs-fixer" version="^3.8.0" location="./tools/php-cs-fixer" copy="false" installed="3.8.0"/>
   <phar name="phpcbf" version="^3.6.2" location="./tools/phpcbf" copy="false" installed="3.6.2"/>
   <phar name="phpcs" version="^3.6.2" location="./tools/phpcs" copy="false" installed="3.6.2"/>
-  <phar name="phpstan" version="^1.4.10" location="./tools/phpstan" copy="false" installed="1.4.10"/>
+  <phar name="phpstan" version="^1.5.4" location="./tools/phpstan" copy="false" installed="1.5.4"/>
   <phar name="infection" version="^0.26.6" location="./tools/infection" copy="false" installed="0.26.6"/>
 </phive>

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,16 +2,16 @@ filter:
   excluded_paths:
     - 'tests/'
   dependency_paths:
+    - 'tools/'
     - 'vendor/'
 
 build:
   dependencies:
     override:
-      - composer update --no-interaction --prefer-dist
+      - composer upgrade --no-interaction --prefer-dist
   nodes:
-    analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/
-      project_setup:
-        override: true
+    analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/ 
+      project_setup: {override: true}
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,14 @@ No hay cambios no liberados.
 
 ## Listado de cambios
 
+### Versión 0.3.1 2022-04-04
+
+La herramienta PHPStan detectó un posible error de mal uso de la propiedad `DOMElement::localName` donde
+puede ser de los tipos `string` o `null`, pero solo se consideraba `string`.
+
+La herramienta PHPStan detectó un posible error de mal uso de la propiedad `DOMElement::parentNode` donde
+se verifica que la propiedad ahora sea de tipo `DOMElement`.
+
 ### Versión 0.3.0 2022-03-16
 
 Se ha descubierto un error en donde dos especificaciones de esquemas del SAT pueden chocar

--- a/src/CfdiToDataNode.php
+++ b/src/CfdiToDataNode.php
@@ -55,7 +55,7 @@ final class CfdiToDataNode
         }
 
         return new Nodes\Node(
-            $element->localName,
+            strval($element->localName),
             $path,
             $this->obtainAttributes($element),
             $convertionChildren,

--- a/src/XsdMaxOccurs/Finder.php
+++ b/src/XsdMaxOccurs/Finder.php
@@ -62,7 +62,7 @@ final class Finder implements FinderInterface
 
     private function findParentElement(DOMElement $node): ?DOMElement
     {
-        for ($node = $node->parentNode; null !== $node; $node = $node->parentNode) {
+        for ($node = $node->parentNode; $node instanceof DOMElement; $node = $node->parentNode) {
             if ('element' !== $node->localName || 'http://www.w3.org/2001/XMLSchema' !== $node->namespaceURI) {
                 continue;
             }


### PR DESCRIPTION
La herramienta PHPStan detectó un posible error de mal uso de la propiedad `DOMElement::localName` donde
puede ser de los tipos `string` o `null`, pero solo se consideraba `string`.

La herramienta PHPStan detectó un posible error de mal uso de la propiedad `DOMElement::parentNode` donde
se verifica que la propiedad ahora sea de tipo `DOMElement`.