### PR TITLE
Prepare version 0.3.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf
 
 # Do not put this files on a distribution package (by .gitignore)
 /tools/                     export-ignore
@@ -18,3 +18,6 @@
 /phpcs.xml.dist             export-ignore
 /phpstan.neon.dist          export-ignore
 /phpunit.xml.dist           export-ignore
+
+# Do not count these files on github code language
+/tests/_files/**            linguist-detectable=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
-          tools: composer:v2, phpcs, cs2pr
+          tools: phpcs, cs2pr
       - name: phpcs
         run: phpcs -q --report=checkstyle | cs2pr
 
@@ -38,13 +38,13 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
-          tools: composer:v2, php-cs-fixer, cs2pr
+          tools: php-cs-fixer, cs2pr
       - name: php-cs-fixer
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
@@ -53,18 +53,18 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: composer:v2, phpstan
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -79,18 +79,18 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: composer:v2
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -108,7 +108,7 @@ jobs:
         php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -121,7 +121,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -136,18 +136,18 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: xdebug
           tools: composer:v2, infection
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.8.0" location="./tools/php-cs-fixer" copy="false" installed="3.8.0"/>
-  <phar name="phpcbf" version="^3.6.2" location="./tools/phpcbf" copy="false" installed="3.6.2"/>
-  <phar name="phpcs" version="^3.6.2" location="./tools/phpcs" copy="false" installed="3.6.2"/>
-  <phar name="phpstan" version="^1.5.4" location="./tools/phpstan" copy="false" installed="1.5.4"/>
-  <phar name="infection" version="^0.26.6" location="./tools/infection" copy="false" installed="0.26.6"/>
+  <phar name="php-cs-fixer" version="^3.11.0" location="./tools/php-cs-fixer" copy="false" installed="3.11.0"/>
+  <phar name="phpcbf" version="^3.7.1" location="./tools/phpcbf" copy="false" installed="3.7.1"/>
+  <phar name="phpcs" version="^3.7.1" location="./tools/phpcs" copy="false" installed="3.7.1"/>
+  <phar name="phpstan" version="^1.8.6" location="./tools/phpstan" copy="false" installed="1.8.6"/>
+  <phar name="infection" version="^0.26.15" location="./tools/infection" copy="false" installed="0.26.15"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -18,16 +18,17 @@ return (new PhpCsFixer\Config())
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
         // symfony
-        // 'class_attributes_separation' => true, // conflict with PSR12
+        'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
@@ -40,6 +41,7 @@ return (new PhpCsFixer\Config())
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ a formato JSON.
 
 Algunas de las convenciones que se siguen son:
 
-- Los elementos con objetos que contienen los atributos y sus elementos hijos.
+- Los elementos son objetos que contienen su valor, los atributos y sus elementos hijos.
 - Los elementos que pueden aparecer más de una vez, son manejados como arreglos.
 - La librería guarda un registro interno de los elementos que pueden aparecer más de una vez.
 
@@ -191,11 +191,11 @@ Note que:
 ## Funcionamiento interno
 
 La conversión parte de un objeto `DOMDocument` que es recorrido nodo a nodo y en cada transformación genera
-un objeto de tipo `Nodes\Node` que contiene sus propiedades básicas de nombre, ruta, atributos e hijos.
+un objeto de tipo `Nodes\Node` que contiene sus propiedades básicas de nombre, ruta, valor de texto, atributos e hijos.
 Los hijos (`Nodes\Children`) son una colección de nodos `Nodes\Node`.
 
 Al momento de exportar a un arreglo `Nodes\Node::toArray()` es cuando se resuelve si los nodos deben agregarse como
-llaves directas a objetos o bien como arreglos de objetos. 
+llaves directas a objetos, o bien, como arreglos de objetos. 
 
 ### Elementos con múltiples apariciones
 
@@ -207,9 +207,10 @@ de nombres del SAT de PhpCfdi [`phpcfdi/sat-ns-registry`](https://github.com/php
 los archivos XSD para interpretar las rutas que contienen `maxOccurs="unbounded"`.
 
 Desde 2021-03-22 se ha agregado un evento desde `phpcfdi/sat-ns-registry` para que notifique a este mismo repositorio
-de que el registro de espacios de nombres cambió.
+que el registro de espacios de nombres cambió.
 
 ### Nodos con texto
+
 El texto o valor que contenga algún nodo XML es exportado a una llave de cadena vacía en el JSON resultante.
 Por ejemplo, el siguiente XML:
 
@@ -218,7 +219,8 @@ Por ejemplo, el siguiente XML:
     <detallista:referenceIdentification type="ON">3</detallista:referenceIdentification>
 </detallista:orderIdentification>
 ```
-genera el siguiente JSON:
+
+Genera el siguiente JSON:
 
 ```json
 {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,16 @@ usa este tipo de estructura. Estos contenidos se consideran como espacios en bla
 
 Gracias `@gam04` por tu contribución.
 
+#### Cambios al entorno de desarrollo
+
+- Se actualizan las herramientas de desarrollo.
+- Se actualiza el flujo de trabajo de integración contínua:
+  - Se utilizan las GitHub Actions versión 3.
+  - Se corren los procesos en PHP 8.1.
+  - Se elimina la dependencia de `composer` donde no se usa.
+- Se actualiza el archivo de configuración de `php-cs-fixer`.
+- Se agrega la configuración en Git para que los finales de línea solo sean `LF`.
+
 ### Versión 0.3.1 2022-04-04
 
 La herramienta PHPStan detectó un posible error de mal uso de la propiedad `DOMElement::localName` donde

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,13 @@ No hay cambios no liberados.
 
 ## Listado de cambios
 
+### Versión 0.3.2 2022-10-01
+
+Permite la lectura del contenido de texto de los nodos, esto es porque el "Complemento Detallista"
+usa este tipo de estructura. Estos contenidos se consideran como espacios en blanco colapsados.
+
+Gracias `@gam04` por tu contribución.
+
 ### Versión 0.3.1 2022-04-04
 
 La herramienta PHPStan detectó un posible error de mal uso de la propiedad `DOMElement::localName` donde

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,3 +5,6 @@
 - ¿Los elementos `Comprobante/Complemento` deberían colapsarse?
 
 - Hacer que `infection` se ejecute con un mínimo requerido en la integración contínua.
+
+- Rehacer la construcción de `PhpCfdi\CfdiToJson\Nodes\Node` para que `$value` no sea opcional.
+  Se puso de esta forma para no romper la compatiblidad con implementaciones actuales.


### PR DESCRIPTION
Permite la lectura del contenido de texto de los nodos, esto es porque el "Complemento Detallista" usa este tipo de estructura. Estos contenidos se consideran como espacios en blanco colapsados.

Gracias @gam04 por tu contribución.

Se hacen además cambios de desarrollo:

- Se actualizan las herramientas de desarrollo.
- Se actualiza el flujo de trabajo de integración contínua:
  - Se utilizan las GitHub Actions versión 3.
  - Se corren los procesos en PHP 8.1.
  - Se elimina la dependencia de `composer` donde no se usa.
- Se actualiza el archivo de configuración de `php-cs-fixer`.
- Se agrega la configuración en Git para que los finales de línea solo sean `LF`.
